### PR TITLE
Fixed padding right of search box

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -266,15 +266,14 @@ a {
 }
 
 .search {
-        position: relative;
         padding: 0 0 1em;
 }
 
 #search {
         display: block;
-        width: 100%;
+        width: 95%;
         border: 2px solid #de1b1b;
-        padding: 0.5rem 1.65rem 0.5rem 0.45rem;
+        padding: 0.5rem 0rem 0.5rem 0.5rem;
         border-radius: 4px;
 }
 


### PR DESCRIPTION
Because of the huge padding right and the width: 100% the search box
overlaped the list of datasets. With this fix the page looks okayish
again.

I personally think the search is very important and therefore should not
only be in the sidebar. Has there been a discussion about this?